### PR TITLE
9.0

### DIFF
--- a/pos_disable_payment/__openerp__.py
+++ b/pos_disable_payment/__openerp__.py
@@ -1,6 +1,6 @@
 {
     'name': "Disable payments in POS",
-    'version': '2.1.0',
+    'version': '2.1.1',
     'author': 'IT-Projects LLC, Ivan Yelizariev',
     'license': 'LGPL-3',
     'category': 'Point Of Sale',

--- a/pos_disable_payment/doc/changelog.rst
+++ b/pos_disable_payment/doc/changelog.rst
@@ -3,6 +3,12 @@
 Changelog
 =========
 
+`2.1.1`
+-------
+
+- User POS settings now got two parameters (allow_decrease_amount and allow_delete_order_line) instead of only one
+(allow_delete_order_line). If first parameter is FALSE than you cant set second one..
+
 `2.0.0`
 -------
 

--- a/pos_disable_payment/models.py
+++ b/pos_disable_payment/models.py
@@ -9,4 +9,5 @@ class pos_config(models.Model):
     allow_delete_order = fields.Boolean('Allow remove non-empty order', default=True)
     allow_discount = fields.Boolean('Allow discount', default=True)
     allow_edit_price = fields.Boolean('Allow edit price', default=True)
+    allow_decrease_amount = fields.Boolean('Allow decrease order line', default=True)
     allow_delete_order_line = fields.Boolean('Allow remove order line', default=True)

--- a/pos_disable_payment/static/src/js/pos_disable_payment.js
+++ b/pos_disable_payment/static/src/js/pos_disable_payment.js
@@ -6,12 +6,12 @@ odoo.define('pos_disable_payment', function(require){
     var core = require('web.core');
     var gui = require('point_of_sale.gui');
     var models = require('point_of_sale.models');    
-    var PosBaseWidget = require('point_of_sale.BaseWidget');    
+    var PosBaseWidget = require('point_of_sale.BaseWidget');
     var _t = core._t;
 
     models.load_models({
         model:  'res.users',
-        fields: ['allow_payments','allow_delete_order','allow_discount','allow_edit_price','allow_delete_order_line'],
+        fields: ['allow_payments','allow_delete_order','allow_discount','allow_edit_price','allow_decrease_amount','allow_delete_order_line'],
         loaded: function(self,users){
             for (var i = 0; i < users.length; i++) {
                 var user = _.find(self.users, function(el){ return el.id == users[i].id; });
@@ -21,7 +21,6 @@ odoo.define('pos_disable_payment', function(require){
             }
         }
     });
-
     // Example of event binding and handling (triggering). Look up binding lower bind('change:cashier' ...
     // Example extending of class (method set_cashier), than was created using extend.
     // /odoo9/addons/point_of_sale/static/src/js/models.js
@@ -127,6 +126,9 @@ odoo.define('pos_disable_payment', function(require){
     screens.NumpadWidget.include({
         clickDeleteLastChar: function(){
             var user = this.pos.cashier || this.pos.user;
+            if(!user.allow_decrease_amount && this.state.get('mode') === 'quantity'){
+                return;
+            }
             if (!user.allow_delete_order_line && this.state.get('buffer') === "" && this.state.get('mode') === 'quantity'){
                 return;
             }

--- a/pos_disable_payment/views.xml
+++ b/pos_disable_payment/views.xml
@@ -19,7 +19,8 @@
                         <field name="allow_delete_order"/>
                         <field name="allow_discount"/>
                         <field name="allow_edit_price"/>
-                        <field name="allow_delete_order_line"/>
+                        <field name="allow_decrease_amount"/>
+                        <field name="allow_delete_order_line" attrs="{'invisible':[('allow_decrease_amount','=',False)]}"/>
                     </group>
             </xpath>
         </field>


### PR DESCRIPTION
User POS settings now got two parameters (allow_decrease_amount and allow_delete_order_line) instead of only one (allow_delete_order_line). If first parameter is FALSE than you cant set second one.
