### PR TITLE
[FIX] increase collecting timer to avoid "sync conflict" problem.

### DIFF
--- a/pos_multi_session/__openerp__.py
+++ b/pos_multi_session/__openerp__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': "Sync POS orders across multiple sessions",
-    'version': '2.0.0',
+    'version': '2.0.1',
     'summary': """Use multiple POS for handling orders""",
     'author': 'IT-Projects LLC, Ivan Yelizariev',
     'license': 'GPL-3',

--- a/pos_multi_session/doc/changelog.rst
+++ b/pos_multi_session/doc/changelog.rst
@@ -3,6 +3,11 @@
 Updates
 =========
 
+`2.0.1`
+-------
+
+- FIX: "Sync conflict" error on slow connection
+
 `2.0.0`
 -------
 

--- a/pos_multi_session/static/src/js/pos_multi_session.js
+++ b/pos_multi_session/static/src/js/pos_multi_session.js
@@ -305,7 +305,7 @@ openerp.pos_multi_session = function(instance){
                 function(){
                     self.ms_update_timeout = false;
                     self.do_ms_update();
-                }, 300);
+                }, 1000);
         },
         ms_remove_order: function(){
             if (!this.ms_check())


### PR DESCRIPTION
The reason of the problem is that some update request could be delivered to
server in a wrong order. If we increase timer, we descrease probability of such
situation, because minimal time between two requests is 1 sec now