### PR TITLE
[FIX] [10.0] pos_multi_session_restaurant: Refresh floor screen on removed order

### DIFF
--- a/pos_multi_session_restaurant/static/src/js/pos_multi_session_restaurant.js
+++ b/pos_multi_session_restaurant/static/src/js/pos_multi_session_restaurant.js
@@ -114,7 +114,7 @@ odoo.define('pos_multi_session_restaurant', function(require){
             }
         },
         on_removed_order: function(removed_order, index, reason){
-            PosModelSuper.prototype.on_removed_order.apply(this, arguments)
+            PosModelSuper.prototype.on_removed_order.apply(this, arguments);
             this.trigger('change:orders-count-on-floor-screen');
         },
         // changes the current table.

--- a/pos_multi_session_restaurant/static/src/js/pos_multi_session_restaurant.js
+++ b/pos_multi_session_restaurant/static/src/js/pos_multi_session_restaurant.js
@@ -113,6 +113,10 @@ odoo.define('pos_multi_session_restaurant', function(require){
                 PosModelSuper.prototype.ms_on_add_order.apply(this, arguments);
             }
         },
+        on_removed_order: function(removed_order, index, reason){
+            PosModelSuper.prototype.on_removed_order.apply(this, arguments)
+            this.trigger('change:orders-count-on-floor-screen');
+        },
         // changes the current table.
         set_table: function(table) {
             var self = this;


### PR DESCRIPTION
`pos_multi_session_restaurant` does not refresh the floor screen on removed order, when only one table has orders. Could fix with triggering `'change:orders-count-on-floor-screen'` on removed order.