### PR TITLE
10.0 pos order calcel add option free reason

### DIFF
--- a/pos_order_cancel/__manifest__.py
+++ b/pos_order_cancel/__manifest__.py
@@ -22,6 +22,7 @@
         "security/ir.model.access.csv",
         "views/template.xml",
         "views/views.xml",
+        "views/pos_config_view.xml",
     ],
     'qweb': [
         'static/src/xml/cancel_order.xml',

--- a/pos_order_cancel/models/models.py
+++ b/pos_order_cancel/models/models.py
@@ -139,4 +139,4 @@ class PosOrderLineCanceled(models.Model):
 class PosConfig(models.Model):
     _inherit = 'pos.config'
     
-    accept_free_reason=fields.Boolean(string="accept free reason",help="the field to send a reason is activate")
+    accept_free_reason=fields.Boolean(string="accept free reason",help="the field to send a reason is activate",default=True)

--- a/pos_order_cancel/models/models.py
+++ b/pos_order_cancel/models/models.py
@@ -135,3 +135,8 @@ class PosOrderLineCanceled(models.Model):
             canceled_date = fields.Datetime.to_string(canceled_date)
             values['canceled_date'] = canceled_date
         return super(PosOrderLineCanceled, self).create(values)
+    
+class PosConfig(models.Model):
+    _inherit = 'pos.config'
+    
+    accept_free_reason=fields.Boolean(string="accept free reason",help="the field to send a reason is activate")

--- a/pos_order_cancel/static/src/js/models.js
+++ b/pos_order_cancel/static/src/js/models.js
@@ -177,19 +177,5 @@ odoo.define('pos_order_cancel.models', function (require) {
             _super_orderline.init_from_JSON.call(this, json);
         },
     });
-    
-    var _super_posmodel = models.PosModel.prototype;
-
-    models.PosModel = models.PosModel.extend({
-        initialize: function (session, attributes) {
-
-            var config_model = _.find(this.models, function(model){
-                return model.model === 'pos.config';
-            });
-            partner_model.fields.push('free_reason');
-
-            return _super_posmodel.initialize.call(this, session, attributes);
-        },
-    });
     return models;
 });

--- a/pos_order_cancel/static/src/js/models.js
+++ b/pos_order_cancel/static/src/js/models.js
@@ -177,5 +177,19 @@ odoo.define('pos_order_cancel.models', function (require) {
             _super_orderline.init_from_JSON.call(this, json);
         },
     });
+    
+    var _super_posmodel = models.PosModel.prototype;
+
+    models.PosModel = models.PosModel.extend({
+        initialize: function (session, attributes) {
+
+            var config_model = _.find(this.models, function(model){
+                return model.model === 'pos.config';
+            });
+            partner_model.fields.push('free_reason');
+
+            return _super_posmodel.initialize.call(this, session, attributes);
+        },
+    });
     return models;
 });

--- a/pos_order_cancel/static/src/js/widgets.js
+++ b/pos_order_cancel/static/src/js/widgets.js
@@ -137,20 +137,24 @@ odoo.define('pos_order_cancel.widgets', function (require) {
             }
         },
         click_confirm: function(){
-            this.gui.close_popup();
-            if( this.options.confirm ){
-                var active_reasons = this.options.reasons.filter(function(item) {
-                    return item.active === true;
-                });
-                var active_reasons_name = [];
-                active_reasons.forEach(function(item) {
-                    active_reasons_name.push(item.name);
-                });
-                var reason = this.$('.popup-confirm-cancellation textarea').val();
-                if (reason) {
-                    reason += "; ";
-                }
-                this.options.confirm.call(this, reason + active_reasons_name.join("; "));
+        	var active_reasons = this.options.reasons.filter(function(item) {
+                return item.active === true;
+            });
+            var active_reasons_name = [];
+            active_reasons.forEach(function(item) {
+                active_reasons_name.push(item.name);
+            });
+            
+            if(this.pos.config.accept_free_reason || active_reasons_name.length>0)
+            {
+                this.gui.close_popup();
+                if( this.options.confirm ){
+                    var reason = this.$('.popup-confirm-cancellation textarea').val();
+                    if (reason) {
+                        reason += "; ";
+                    }
+                    this.options.confirm.call(this, reason + active_reasons_name.join("; "));
+	            }
             }
         },
     });

--- a/pos_order_cancel/static/src/js/widgets.js
+++ b/pos_order_cancel/static/src/js/widgets.js
@@ -137,7 +137,7 @@ odoo.define('pos_order_cancel.widgets', function (require) {
             }
         },
         click_confirm: function(){
-        	var active_reasons = this.options.reasons.filter(function(item) {
+            var active_reasons = this.options.reasons.filter(function(item) {
             return item.active === true;
             });
             var active_reasons_name = [];

--- a/pos_order_cancel/static/src/js/widgets.js
+++ b/pos_order_cancel/static/src/js/widgets.js
@@ -138,15 +138,13 @@ odoo.define('pos_order_cancel.widgets', function (require) {
         },
         click_confirm: function(){
         	var active_reasons = this.options.reasons.filter(function(item) {
-                return item.active === true;
+            return item.active === true;
             });
             var active_reasons_name = [];
             active_reasons.forEach(function(item) {
                 active_reasons_name.push(item.name);
             });
-            
-            if(this.pos.config.accept_free_reason || active_reasons_name.length>0)
-            {
+            if(this.pos.config.accept_free_reason || active_reasons_name.length>0){
                 this.gui.close_popup();
                 if( this.options.confirm ){
                     var reason = this.$('.popup-confirm-cancellation textarea').val();
@@ -154,7 +152,7 @@ odoo.define('pos_order_cancel.widgets', function (require) {
                         reason += "; ";
                     }
                     this.options.confirm.call(this, reason + active_reasons_name.join("; "));
-	            }
+                }
             }
         },
     });

--- a/pos_order_cancel/static/src/xml/cancel_order.xml
+++ b/pos_order_cancel/static/src/xml/cancel_order.xml
@@ -6,7 +6,7 @@
             <div class="popup popup-confirm-cancellation">
                 <p class="title"><t t-esc=" widget.options.title || '' " /></p>
                 <t t-if="widget.pos.config.accept_free_reason">
-                	<textarea rows="1" cols="44" placeholder="Reason"></textarea>
+                    <textarea rows="1" cols="44" placeholder="Reason"></textarea>
                 </t>
                 <div class="cancelled-reason">
                     <ul>
@@ -29,7 +29,7 @@
                 </div>
                 <div class="footer centered">
                 <t t-if="widget.pos.config.accept_free_reason">
-                	<div class="button cancel">
+                    <div class="button cancel">
                         Cancel
                     </div>
                 </t>

--- a/pos_order_cancel/static/src/xml/cancel_order.xml
+++ b/pos_order_cancel/static/src/xml/cancel_order.xml
@@ -5,7 +5,7 @@
         <div class="modal-dialog">
             <div class="popup popup-confirm-cancellation">
                 <p class="title"><t t-esc=" widget.options.title || '' " /></p>
-<t t-if="widget.pos.config.accept_free_reason">
+                <t t-if="widget.pos.config.accept_free_reason">
                     <textarea rows="1" cols="44" placeholder="Reason"></textarea>
                 </t>
                 <div class="cancelled-reason">

--- a/pos_order_cancel/static/src/xml/cancel_order.xml
+++ b/pos_order_cancel/static/src/xml/cancel_order.xml
@@ -5,7 +5,7 @@
         <div class="modal-dialog">
             <div class="popup popup-confirm-cancellation">
                 <p class="title"><t t-esc=" widget.options.title || '' " /></p>
-                <t t-if="widget.pos.config.accept_free_reason">
+<t t-if="widget.pos.config.accept_free_reason">
                     <textarea rows="1" cols="44" placeholder="Reason"></textarea>
                 </t>
                 <div class="cancelled-reason">

--- a/pos_order_cancel/static/src/xml/cancel_order.xml
+++ b/pos_order_cancel/static/src/xml/cancel_order.xml
@@ -5,7 +5,9 @@
         <div class="modal-dialog">
             <div class="popup popup-confirm-cancellation">
                 <p class="title"><t t-esc=" widget.options.title || '' " /></p>
-                <textarea rows="1" cols="44" placeholder="Reason"></textarea>
+                <t t-if="widget.pos.config.accept_free_reason">
+                	<textarea rows="1" cols="44" placeholder="Reason"></textarea>
+                </t>
                 <div class="cancelled-reason">
                     <ul>
                         <t t-if="widget.buttons">
@@ -26,9 +28,11 @@
                     </ul>
                 </div>
                 <div class="footer centered">
-                    <div class="button cancel">
+                <t t-if="widget.pos.config.accept_free_reason">
+                	<div class="button cancel">
                         Cancel
                     </div>
+                </t>
                     <div class="button confirm">
                         Ok
                     </div>

--- a/pos_order_cancel/views/pos_config_view.xml
+++ b/pos_order_cancel/views/pos_config_view.xml
@@ -5,7 +5,7 @@
         <field name="model">pos.config</field>
         <field name="inherit_id" ref="point_of_sale.view_pos_config_form"/>
         <field name="arch" type="xml">
-   			<xpath expr="//field[@name='iface_display_categ_images']" position="after">
+   		    <xpath expr="//field[@name='iface_display_categ_images']" position="after">
                 <field name="accept_free_reason"/>
             </xpath>
          </field>

--- a/pos_order_cancel/views/pos_config_view.xml
+++ b/pos_order_cancel/views/pos_config_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_pos_config_cancel_form" model="ir.ui.view">
+        <field name="name">pos.config.cancel.form.view</field>
+        <field name="model">pos.config</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_config_form"/>
+        <field name="arch" type="xml">
+   			<xpath expr="//field[@name='iface_display_categ_images']" position="after">
+                <field name="accept_free_reason"/>
+            </xpath>
+         </field>
+    </record>
+</odoo>


### PR DESCRIPTION
hello @yelizariev 

I add an option to choose if we accept a free reason ( normal mode) or if the salesman must choose one or more specific reasons.

In the second point, we desable the textarea ( input box) and the button "cancel". The button "validate" is disable when the salesman don't choose the reason.