### PR TITLE
[add] show canceled lines only for the current company

### DIFF
--- a/pos_order_cancel/__manifest__.py
+++ b/pos_order_cancel/__manifest__.py
@@ -19,6 +19,7 @@
     ],
     "external_dependencies": {"python": [], "bin": []},
     "data": [
+        "security/security.xml",
         "security/ir.model.access.csv",
         "views/template.xml",
         "views/views.xml",

--- a/pos_order_cancel/security/security.xml
+++ b/pos_order_cancel/security/security.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+<data noupdate="1">
+
+    <record model="ir.rule" id="show_cancel_lines_only_for_user_current_company">
+        <field name="name">show cancel lines only for the user current company </field>
+        <field name="model_id" ref="model_pos_order_line_canceled"/>
+        <field name="global" eval="True"/>
+        <field name="domain_force">[('order_id.company_id', '=', user.company_id.id)]
+        </field>
+    </record>
+    
+</data>
+</odoo>


### PR DESCRIPTION
If we have a multi company,  in the report canceled/refund lines, we have all lines.
I propose to show only the lines of the current company.