### PR TITLE
[FIX] 10.0 - pos_multi_session_restaurant - dont error out if order.table is null

### DIFF
--- a/pos_multi_session_restaurant/static/src/js/pos_multi_session_restaurant.js
+++ b/pos_multi_session_restaurant/static/src/js/pos_multi_session_restaurant.js
@@ -127,7 +127,7 @@ odoo.define('pos_multi_session_restaurant', function(require){
                     return order.uid == data.uid;
                 });
             }
-            if (order && order.table.id != data.table_id) {
+            if (order && order.table && order.table.id != data.table_id) {
                 order.transfer = true;
                 order.destroy({'reason': 'abandon'});
             }


### PR DESCRIPTION
Address #518 

No idea how order.table can be null though, @yelizariev any clue?