### PR TITLE
[10.0][FIX] pos_multi_session: sync add_orderline

### DIFF
--- a/pos_multi_session/static/src/js/pos_multi_session.js
+++ b/pos_multi_session/static/src/js/pos_multi_session.js
@@ -4,6 +4,7 @@
  * Copyright 2016-2018 Dinar Gabbasov <https://it-projects.info/team/GabbasovDinar>
  * Copyright 2017 Kolushov Alexandr <https://it-projects.info/team/KolushovAlexandr>
  * Copyright 2017 David Arnold
+ * Copyright 2018 Attila Szollosi
  * License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html). */
 
 odoo.define('pos_multi_session', function(require){
@@ -492,6 +493,10 @@ odoo.define('pos_multi_session', function(require){
             this.bind('change:sync', function(){
                 self.ms_update();
             });
+        },
+        add_orderline: function(line){
+            OrderSuper.prototype.add_orderline.apply(this, arguments);
+            line.order.trigger('change:sync');
         },
         remove_orderline: function(line){
             OrderSuper.prototype.remove_orderline.apply(this, arguments);


### PR DESCRIPTION
This change was needed to make [my addon](https://www.odoo.com/apps/modules/10.0/pos_merge_orders/) work with the pos_multi_session module.