### PR TITLE
:heart_eyes: don't use the 'change' trigger to save to the local storage

### DIFF
--- a/pos_multi_session/__manifest__.py
+++ b/pos_multi_session/__manifest__.py
@@ -9,7 +9,7 @@
     "category": "Point Of Sale",
     "live_test_url": 'http://apps.it-projects.info/shop/product/pos-multi-session?version=11.0',
     "images": ["images/pos-multi-session.png"],
-    "version": "11.0.4.2.0",
+    "version": "11.0.4.2.1",
     "application": False,
 
     "author": "IT-Projects LLC, Ivan Yelizariev",

--- a/pos_multi_session/doc/changelog.rst
+++ b/pos_multi_session/doc/changelog.rst
@@ -1,3 +1,7 @@
+`4.2.1`
+-------
+- **FIX:** Rerendering the Products list after change a current order
+
 `4.2.0`
 -------
 - **FIX:** 'order_line.node' is undefined

--- a/pos_multi_session/static/src/js/pos_multi_session.js
+++ b/pos_multi_session/static/src/js/pos_multi_session.js
@@ -611,8 +611,8 @@ odoo.define('pos_multi_session', function(require){
                 this.pos.pos_session.order_ID = this.pos.pos_session.order_ID + 1;
                 this.trigger('change:update_new_order');
             } else {
-                // 'change' trigger saves order to db
-                this.trigger('change');
+                // save order to the local storage
+                this.save_to_db();
             }
             if (!this.ms_active()){
                 return;


### PR DESCRIPTION
If an order is changed every time this PR fixes an issue with rerendering of the product list. It's related to new changes in Odoo 11.0 https://github.com/odoo/odoo/blame/11.0/addons/point_of_sale/static/src/js/screens.js#L846
