### PR TITLE
:ambulance: fix rerendering the Products list after change a current order

### DIFF
--- a/pos_multi_session/__manifest__.py
+++ b/pos_multi_session/__manifest__.py
@@ -9,7 +9,7 @@
     "category": "Point Of Sale",
     "live_test_url": 'http://apps.it-projects.info/shop/product/pos-multi-session?version=11.0',
     "images": ["images/pos-multi-session.png"],
-    "version": "11.0.4.2.2",
+    "version": "11.0.4.2.3",
     "application": False,
 
     "author": "IT-Projects LLC, Ivan Yelizariev",

--- a/pos_multi_session/doc/changelog.rst
+++ b/pos_multi_session/doc/changelog.rst
@@ -1,129 +1,134 @@
+`4.2.3`
+-------
+
+**Fix:** Before this fix if we have a rerender of the product list every time, then we will get a hang and slow response of the system.
+
 `4.2.2`
 -------
 
-- **FIX:** `Longpoll Handling Error` related to property of undefined
+**Fix:** `Longpoll Handling Error` related to property of undefined
 
 `4.2.1`
 -------
 
-- **FIX:** Error related to longpoll updates of paid orders
-- **FIX:** Cannot read property then of undefined or request_sync_all is undefined
+**Fix:** Error related to longpoll updates of paid orders
+**Fix:** Cannot read property then of undefined or request_sync_all is undefined
 
 `4.2.0`
 -------
-- **FIX:** 'order_line.node' is undefined
-- **NEW:** Added synchronization among the same POS
-- **IMP:** Orderlines added to existing orders in offline mode won't be lost after reestablishing a connection
-- **IMP:** Warning message "No connection to the server..." is automatically closing after connection is reestablished
+**Fix:** 'order_line.node' is undefined
+**New:** Added synchronization among the same POS
+**Improvement:** Orderlines added to existing orders in offline mode won't be lost after reestablishing a connection
+**Improvement:** Warning message "No connection to the server..." is automatically closing after connection is reestablished
 
 `4.1.1`
 -------
-- **IMP:** Multi-Session methods renamings
+**Improvement:** Multi-Session methods renamings
 
 `4.1.0`
 -------
-- **NEW:** Field "Active" to enable/disable synchronization for POSes. The multi-session parameter is required now to provide compatibility with "POS Multi Session Menu" module and other modules that put common settings in "POS Multi Session"
+**New:** Field "Active" to enable/disable synchronization for POSes. The multi-session parameter is required now to provide compatibility with "POS Multi Session Menu" module and other modules that put common settings in "POS Multi Session"
 
 `4.0.6`
 -------
-- **FIX:** Incompatibility with pos_order_cancel_restaurant: it showed *Synchronization error* on removing order
+**Fix:** Incompatibility with pos_order_cancel_restaurant: it showed *Synchronization error* on removing order
 
 `4.0.5`
 -------
-- **IMP:** Improved performance
+**Improvement:** Improved performance
 
 `4.0.4`
 -------
-- **FIX:** Remove some orders after revision error
+**Fix:** Remove some orders after revision error
 
 `4.0.3`
 -------
-- **IMP:** All data are updated during POS loading
-- **IMP:** Improved orderline updating speed after synchronization with server
+**Improvement:** All data are updated during POS loading
+**Improvement:** Improved orderline updating speed after synchronization with server
 
 `4.0.2`
 -------
-- **IMP:** Dramatically improved performance
+**Improvement:** Dramatically improved performance
 
 `4.0.1`
 -------
-- **IMP:** Refactoring the code to fix a slow POS synchronization
+**Improvement:** Refactoring the code to fix a slow POS synchronization
 
 `4.0.0`
 -------
-- REF: Server side of synchronization is moved to the separate module ``pos_multi_session_sync``
-- NEW: Allow to make synchronization via local server
-- NEW: Fiscal position synchronization
+**Improvement:** Server side of synchronization is moved to the separate module ``pos_multi_session_sync``
+**New:** Allow to make synchronization via local server
+**New:** Fiscal position synchronization
 
 `3.1.0`
 -------
 
-- NEW: Added "Multi-session Settings" form.
-- NEW: Added unsynchronized POS in Demo.
-- NEW: Added unittests.
+**New:** Added "Multi-session Settings" form.
+**New:** Added unsynchronized POS in Demo.
+**New:** Added unittests.
 
 `3.0.4`
 -------
 
-- FIX: Errors in case of an empty multi_session_id field.
+**Fix:** Errors in case of an empty multi_session_id field.
 
 `3.0.3`
 -------
 
-- FIX: KeyError: 'sequence_number'.
+**Fix:** KeyError: 'sequence_number'.
 
 `3.0.2`
 -------
 
-- FIX: Remove unpaid orders, once all synced sessions are closed.
+**Fix:** Remove unpaid orders, once all synced sessions are closed.
 
 `3.0.1`
 -------
 
-- FIX: Issue on sessions synchronization after order transfer.
+**Fix:** Issue on sessions synchronization after order transfer.
 
 `3.0.0`
 -------
 
-- FIX: Added a queue for request sending that allows to fix the syncronization error on slow or lost  connection
-- NEW: Added connection status with server to POS interface
-- NEW: Create new orders even if the connection with server temporarily has been lost
+**Fix:** Added a queue for request sending that allows to fix the syncronization error on slow or lost  connection
+**New:** Added connection status with server to POS interface
+**New:** Create new orders even if the connection with server temporarily has been lost
 
 `2.0.1`
 -------
 
-- FIX: "Sync conflict" error on slow connection
+**Fix:** "Sync conflict" error on slow connection
 
 `2.0.0`
 -------
 
-- NEW: Protection against concurrent or obsolete order update requests
-- NEW: Stable order numbering: no duplicates, no omissions. Use word "New" for unregistered empty orders.
-- NEW: Restoring after connection problems
+**New:** Protection against concurrent or obsolete order update requests
+**New:** Stable order numbering: no duplicates, no omissions. Use word "New" for unregistered empty orders.
+**New:** Restoring after connection problems
 
 `1.0.4`
 -------
-- FIX: Print only not printed order lines (*Order* button).
+**Fix:** Print only not printed order lines (*Order* button).
 
 `1.0.3`
 -------
-- IMP: For pos restaurant compatibility. Sync notes. Sync guests.
+**Improvement:** For pos restaurant compatibility. Sync notes. Sync guests.
 
 `1.0.2`
 -------
-- FIX: For pos restaurant compatibility. Sync printed positions.
+**Fix:** For pos restaurant compatibility. Sync printed positions.
 
 `1.0.1`
 -------
 
-- Fix.Orders some times was out of sync. Now its ok.
-- Fix a bug related to updates in built-in bus module from Jan 20th 2016: https://github.com/odoo/odoo/commit/8af3841cb25cee33fd503ebe692abb8f98d4840a
-- Added demo data.
-- New: keep empty order. In previous version we deleted it when new Order from another POS is come. Now you can set it up in settings.
-- New: switch on income order if active order is empty. You can chose to switch on new income order or not.
+**Fix:** Orders some times was out of sync. Now its ok.
+**Fix:** Fix a bug related to updates in built-in bus module from Jan 20th 2016: https://github.com/odoo/odoo/commit/8af3841cb25cee33fd503ebe692abb8f98d4840a
+**New:** Added demo data.
+**New:** keep empty order. In previous version we deleted it when new Order from another POS is come. Now you can set it up in settings.
+**New:** switch on income order if active order is empty. You can chose to switch on new income order or not.
 
 
 `1.0.0`
 -------
 
-- init version
+**Init version**

--- a/pos_multi_session/static/src/js/pos_multi_session.js
+++ b/pos_multi_session/static/src/js/pos_multi_session.js
@@ -404,7 +404,7 @@ odoo.define('pos_multi_session', function(require){
                 }
                 line.offline_orderline = false;
             });
-            if (added_new_lines) {
+            if (added_new_lines && this.get_order() && order.uid === this.get_order().uid) {
                 order.trigger('change:newLines', order);
             }
             _.each(not_found, function(uid){
@@ -619,8 +619,8 @@ odoo.define('pos_multi_session', function(require){
                 this.pos.pos_session.order_ID = this.pos.pos_session.order_ID + 1;
                 this.trigger('change:update_new_order');
             } else {
-                // 'change' trigger saves order to db
-                this.trigger('change');
+                // save order to the local storage
+                this.save_to_db();
             }
             if (!this.ms_active()){
                 return;


### PR DESCRIPTION
Before this fix, if we have a rerender of the product list every time, then we will get a hang and slow response of the system.

P.S. this PR is made using cherry-pick from https://github.com/it-projects-llc/pos-addons/pull/809/commits/fab34c7623d7951278eff5fa663587d9d10c28f6