### PR TITLE
Revert ":zap: orders_history update list button"

### DIFF
--- a/pos_orders_history/__manifest__.py
+++ b/pos_orders_history/__manifest__.py
@@ -9,7 +9,7 @@
     "category": "Point of Sale",
     # "live_test_url": "http://apps.it-projects.info/shop/product/pos-orders-history?version=11.0",
     "images": ['images/pos_orders_history_main.png'],
-    "version": "11.0.1.2.0",
+    "version": "11.0.1.2.1",
     "application": False,
 
     "author": "IT-Projects LLC, Dinar Gabbasov",

--- a/pos_orders_history/doc/changelog.rst
+++ b/pos_orders_history/doc/changelog.rst
@@ -3,6 +3,11 @@
 Updates
 =======
 
+`1.2.1`
+-------
+
+**Improvement:** Remove the "Update order list" button because the orders are updated instantly now
+
 `1.2.0`
 -------
 

--- a/pos_orders_history/static/src/css/pos.css
+++ b/pos_orders_history/static/src/css/pos.css
@@ -8,10 +8,6 @@
     width: 100%;
     line-height: 40px;
 }
-.pos .orders-list-screen .update_history{
-    display: inline-block;
-    position: relative;
-}
 .pos .orders-list-screen .order-list th,
 .pos .orders-list-screen .order-list td {
     padding: 0px 8px;

--- a/pos_orders_history/static/src/js/models.js
+++ b/pos_orders_history/static/src/js/models.js
@@ -57,53 +57,6 @@ odoo.define('pos_orders_history.models', function (require) {
                 args: [[['order_id', '=', id]]]
             });
         },
-        manual_update_order_history: function() {
-            var self = this;
-            var def = new $.Deferred();
-            this.get_order_histories().then(function(data) {
-                if (!data) {
-                    def.resolve();
-                    return;
-                }
-
-                self.update_orders_history(data);
-                self.get_order_lines(_.pluck(data, 'id')).then(function(lines){
-                    self.update_orders_history_lines(lines);
-                    def.resolve();
-                });
-
-            });
-            return def;
-        },
-        get_order_histories: function() {
-            var domain = function(self) {
-                var state = ['paid'];
-                if (self.config.show_cancelled_orders) {
-                    state.push('cancel');
-                }
-                if (self.config.show_posted_orders) {
-                    state.push('done');
-                }
-                var res = [['state','in',state]];
-                if (self.config.current_day_orders_only) {
-                    res.push(['date_order', '>=', self.get_date()]);
-                }
-                return res;
-            };
-
-            return rpc.query({
-                model: 'pos.order',
-                method: 'search_read',
-                args: [domain(this)]
-            });
-        },
-        get_order_lines: function(order_ids) {
-            return rpc.query({
-                model: 'pos.order.line',
-                method: 'search_read',
-                args: [[['order_id','in',order_ids]]]
-            });
-        },
         update_orders_history: function (orders) {
             var self = this,
                 orders_to_update = [];

--- a/pos_orders_history/static/src/js/screens.js
+++ b/pos_orders_history/static/src/js/screens.js
@@ -14,7 +14,9 @@ odoo.define('pos_orders_history.screens', function (require) {
     screens.OrdersHistoryButton = screens.ActionButtonWidget.extend({
         template: 'OrdersHistoryButton',
         button_click: function () {
-            this.gui.show_screen('orders_history_screen');
+            if (this.pos.db.pos_orders_history.length) {
+                this.gui.show_screen('orders_history_screen');
+            }
         },
     });
     screens.define_action_button({
@@ -67,13 +69,6 @@ odoo.define('pos_orders_history.screens', function (require) {
             this.$('.filters .table-filter').click(function (e) {
                 e.stopImmediatePropagation();
                 self.change_filter('table', $(this));
-            });
-
-            this.$('.button.update_history').off().click(function (e) {
-                self.pos.manual_update_order_history().then(function() {
-                    orders = self.pos.db.get_sorted_orders_history(1000);
-                    self.render_list(orders);
-                });
             });
 
             this.$('.order-list-contents').delegate('.order-line td', 'click', function (event) {

--- a/pos_orders_history/static/src/xml/pos.xml
+++ b/pos_orders_history/static/src/xml/pos.xml
@@ -18,9 +18,6 @@
                         <i class='fa fa-angle-double-left'></i>
                         Back
                     </span>
-                    <span class='button update_history'>
-                        Update List
-                    </span>
                     <span class="filters">
                         <i class='fa fa-filter'></i>
                         Filters


### PR DESCRIPTION
This reverts commit 033664556c12999f78a334dee5745629a0450d1c.

I think we don't need to use the changes. These changes are not needed because all updates should come instantly. Also, this module in pos-addons v 10.0 has changes https://github.com/it-projects-llc/pos-addons/commit/8d386d0c6002d52524ee04a9e657c841f0d63b9d#diff-6200f6049d7dfe741e4966628ac47a31 which fix some problems of instant updates. In any case, you must test with changes from 10.0 before you can accept the PR.