### PR TITLE
🛡 pos_keyboard: function disconect not working

### DIFF
--- a/pos_keyboard/static/src/js/pos.js
+++ b/pos_keyboard/static/src/js/pos.js
@@ -270,7 +270,7 @@ odoo.define('pos_keyboard.pos', function (require) {
         // stops catching keyboard events 
         disconnect: function(){
             $('body').off('keyup', '');
-            self.active = false;
+            this.active = false;
         }
     });
     


### PR DESCRIPTION
If you go to payment screen and comeback to product screen, keyboard is not working