### PR TITLE
12.0 pos mobile fix clientlist

### DIFF
--- a/pos_mobile/README.rst
+++ b/pos_mobile/README.rst
@@ -10,6 +10,7 @@ Credits
 Contributors
 ------------
 * `Dinar Gabbasov <https://it-projects.info/team/GabbasovDinar>`__
+* `Eugene Molotov <https://github.com/em230418>`__
 
 Sponsors
 --------
@@ -36,4 +37,4 @@ Usage instructions: `<doc/index.rst>`_
 
 Changelog: `<doc/changelog.rst>`_
 
-Tested on Odoo 11.0 ee2b9fae3519c2494f34dacf15d0a3b5bd8fbd06
+Tested on Odoo 12.0 472bfdca561fcdf3a535c4c92cadf0ede1d4fab4

--- a/pos_mobile/__manifest__.py
+++ b/pos_mobile/__manifest__.py
@@ -4,7 +4,7 @@
     "category": "Point of Sale",
     # "live_test_url": "http://apps.it-projects.info/shop/product/pos-mobile-ui?version=12.0",
     "images": ["images/pos_mobile.png"],
-    "version": "12.0.1.2.1",
+    "version": "12.0.1.2.2",
     "application": False,
 
     "author": "IT-Projects LLC, Dinar Gabbasov",

--- a/pos_mobile/doc/changelog.rst
+++ b/pos_mobile/doc/changelog.rst
@@ -1,3 +1,9 @@
+`1.2.2`
+-------
+
+- **Fix:** Customer list was not shown
+- **Fix:** Customer list was not scrollable
+
 `1.2.1`
 -------
 

--- a/pos_mobile/static/src/css/pos_mobile_styles.css
+++ b/pos_mobile/static/src/css/pos_mobile_styles.css
@@ -1586,9 +1586,6 @@ pos.mobile .clientlist-screen .top-content .button {
     display: inline-block;
 }
 /*Mobile screen*/
-.pos.mobile .window {
-    display: none;
-}
 .pos.mobile .mobile-active-screen {
     display: block;
 }

--- a/pos_mobile/static/src/css/pos_mobile_styles.css
+++ b/pos_mobile/static/src/css/pos_mobile_styles.css
@@ -1133,7 +1133,6 @@ pos.mobile .clientlist-screen .top-content .button {
 }
 .pos.mobile .clientlist-screen .subwindow:nth-child(2) .subwindow-container-fix {
     border-bottom: 8px solid rgb(110,200,155) !important;
-    overflow: hidden!important;
 }
 .ios .pos.mobile .clientlist-screen .subwindow:nth-child(2) .subwindow-container-fix {
     overflow: hidden!important;

--- a/pos_mobile/static/src/js/tour.js
+++ b/pos_mobile/static/src/js/tour.js
@@ -74,6 +74,19 @@ odoo.define('pos_mobile.tour', function(require) {
         }];
     }
 
+    function select_customer(customer_name) {
+        return [{
+            trigger: '.js_customer_name:visible',
+            content: "click on Customer button",
+        }, {
+            trigger: 'table.client-list:visible td:contains("' + customer_name + '")',
+            content: "Click on customer",
+        }, {
+            trigger: '.button.next',
+            content: "Set customer",
+        }];
+    }
+
     var steps = [{
         trigger: '.o_main_content:has(.loader:hidden)',
         content: 'waiting for loading to finish',
@@ -101,6 +114,7 @@ odoo.define('pos_mobile.tour', function(require) {
 
     steps = steps.concat(goto_payment_screen_and_select_payment_method());
     steps = steps.concat(generate_payment_screen_keypad_steps("0.90"));
+    steps = steps.concat(select_customer("Brandon Freeman"));
     steps = steps.concat(finish_order());
 
     steps = steps.concat([{


### PR DESCRIPTION
Reason is that `$('.pos.mobile .window').css({display: 'table'})` from `change_screen_type` was not setting style for all elements in selector due to some bug in jquery 1.11.1. But somehow
`$('.pos.mobile .window').css({display: 'none'})` is working correct, so it works correctly without this css rule.