### PR TITLE
:shield: travis: use python3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "3.5"
+  - "3.6"
 
 sudo: false
 cache: pip


### PR DESCRIPTION
It's a try to fix encoding problem on printing HTML in random tour errors

https://api.travis-ci.com/v3/job/212575529/log.txt
'ascii' codec can't encode character u'\u20ac' in position 7: ordinal not in range(128)