### PR TITLE
[10.0] pos_debt_notebook: fix some bugs

### DIFF
--- a/pos_debt_notebook/data/demo.xml
+++ b/pos_debt_notebook/data/demo.xml
@@ -10,7 +10,7 @@
 
         <record id="product_credit_product" model="product.product">
             <field name="name">Credits top-up</field>
-            <field name="default_code">POS-DEBT</field>
+            <field name="default_code">POS-DEBT-CREDIT</field>
             <field name="sale_ok" eval="True"/>
             <field name="available_in_pos" eval="True"/>
             <field name="list_price">1</field>

--- a/pos_debt_notebook/models.py
+++ b/pos_debt_notebook/models.py
@@ -237,6 +237,7 @@ class PosConfig(models.Model):
                 'code': 'XDEBT',
                 'user_type_id': self.env.ref('account.data_account_type_current_assets').id,
                 'company_id': user.company_id.id,
+                'reconcile': True,
             })
             self.env['ir.model.data'].create({
                 'name': 'debt_account_for_company' + str(user.company_id.id),

--- a/pos_debt_notebook/static/src/js/pos.js
+++ b/pos_debt_notebook/static/src/js/pos.js
@@ -1051,7 +1051,7 @@ odoo.define('pos_debt_notebook.pos', function (require) {
                 var order = self.pos.get_order();
                 if (order) {
                     var lastorderline = order.get_last_orderline();
-                    if (lastorderline === null && self.pos.config.debt_dummy_product_id){
+                    if (lastorderline === undefined && self.pos.config.debt_dummy_product_id){
                         var dummy_product = self.pos.db.get_product_by_id(
                             self.pos.config.debt_dummy_product_id[0]);
                         order.add_product(dummy_product, {'price': 0});


### PR DESCRIPTION
1) create account of debt journal with reconcile=True
2) When we have demo data, don't create 2 products with same default_code
3) Partial fix for button "Pay Full Debt" on customer list in POS frontend. The feature triggered by a click on that button is still buggy: in some scenarios, the payment line is not created.