### PR TITLE
:ambulance: pos_invoice_pay: correct definition of invoice_cashier_selection and sale_order_cashier_selection fields

### DIFF
--- a/pos_invoice_pay/models.py
+++ b/pos_invoice_pay/models.py
@@ -168,12 +168,12 @@ class PosConfig(models.Model):
     invoice_cashier_selection = fields.Boolean(
         string="Select Invoice Cashier",
         help="Ask for a cashier when fetch invoices",
-        defaul=True,
+        default=True,
     )
     sale_order_cashier_selection = fields.Boolean(
         string="Select Sale Order Cashier",
         help="Ask for a cashier when fetch orders",
-        defaul=True,
+        default=True,
     )
 
 


### PR DESCRIPTION
Такое исправление можно принимать вплоть до 13.0. На более ранние версии не смотрел.