### PR TITLE
[FIX] POS order return impossible (pos_orderline_absolute_discount)

### DIFF
--- a/pos_orderline_absolute_discount/models/pos_order_model.py
+++ b/pos_orderline_absolute_discount/models/pos_order_model.py
@@ -53,6 +53,8 @@ class PosOrderLine(models.Model):
                 if fpos
                 else line.tax_ids
             )
+            price = line.price_unit
+            taxes = tax_ids_after_fiscal_position.compute_all(price, self.order_id.pricelist_id.currency_id, self.qty, product=self.product_id, partner=self.order_id.partner_id)
             if line.absolute_discount:
                 price = line.price_unit - line.absolute_discount
                 taxes = tax_ids_after_fiscal_position.compute_all(
@@ -62,12 +64,10 @@ class PosOrderLine(models.Model):
                     product=line.product_id,
                     partner=line.order_id.partner_id,
                 )
-                line.update(
-                    {
-                        "price_subtotal_incl": taxes["total_included"],
-                        "price_subtotal": taxes["total_excluded"],
-                    }
-                )
+            return {
+                    "price_subtotal_incl": taxes["total_included"],
+                    "price_subtotal": taxes["total_excluded"],
+                }
 
     @api.onchange("qty", "discount", "price_unit", "tax_ids", "absolute_discount")
     def _onchange_qty(self):

--- a/pos_orderline_absolute_discount/models/pos_order_model.py
+++ b/pos_orderline_absolute_discount/models/pos_order_model.py
@@ -45,7 +45,7 @@ class PosOrderLine(models.Model):
         "price_unit", "tax_ids", "qty", "discount", "product_id", "absolute_discount"
     )
     def _compute_amount_line_all(self):
-        super(PosOrderLine, self)._compute_amount_line_all()
+        res = super(PosOrderLine, self)._compute_amount_line_all()
         for line in self:
             fpos = line.order_id.fiscal_position_id
             tax_ids_after_fiscal_position = (
@@ -53,8 +53,6 @@ class PosOrderLine(models.Model):
                 if fpos
                 else line.tax_ids
             )
-            price = line.price_unit
-            taxes = tax_ids_after_fiscal_position.compute_all(price, self.order_id.pricelist_id.currency_id, self.qty, product=self.product_id, partner=self.order_id.partner_id)
             if line.absolute_discount:
                 price = line.price_unit - line.absolute_discount
                 taxes = tax_ids_after_fiscal_position.compute_all(
@@ -64,10 +62,13 @@ class PosOrderLine(models.Model):
                     product=line.product_id,
                     partner=line.order_id.partner_id,
                 )
-            return {
-                    "price_subtotal_incl": taxes["total_included"],
-                    "price_subtotal": taxes["total_excluded"],
-                }
+                res.update(
+                    {
+                        "price_subtotal_incl": taxes["total_included"],
+                        "price_subtotal": taxes["total_excluded"],
+                    }
+                )
+        return res
 
     @api.onchange("qty", "discount", "price_unit", "tax_ids", "absolute_discount")
     def _onchange_qty(self):


### PR DESCRIPTION
Hello, here is a pull request to validate an article return with or without "absolute_discount".

At the beginning the return of article was possible only when there was an absolute_discount (discount by number, not percentage).

Now there is the return no matter what.
I tested it in all possibilities, from ticket to invoice.

Thanks